### PR TITLE
feat: Overhaul navigation, add social login, and update theme

### DIFF
--- a/resources/js/components/navigation.tsx
+++ b/resources/js/components/navigation.tsx
@@ -12,8 +12,8 @@ import { Link } from '@inertiajs/react';
 import * as React from 'react';
 
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
-import UserNav from '@/components/user-nav';
 import AppearanceToggleDropdown from '@/components/appearance-dropdown';
+import UserNav from '@/components/user-nav';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
@@ -99,14 +99,10 @@ export default function Navigation() {
                         </Button>
                     </SheetTrigger>
                     <SheetContent side="right" className={`p-6`}>
-                        <div className="mb-6 flex items-center justify-between">
-                            <a href="/" className="flex items-center space-x-2">
-                                <Zap
-                                    className={`size-9 bg-white text-primary fill-primary rounded-sm p-1.5 -rotate-2`}
-                                />
-                                <span className="font-bold">Token Forge</span>
-                            </a>
-                        </div>
+                        <a href="/" className="mr-6 flex items-center space-x-2">
+                            <Zap className={`size-9 bg-white text-primary fill-primary rounded-sm p-1.5 -rotate-2`} />
+                            <span className="font-bold">Token Forge</span>
+                        </a>
                         <div className="divide-y divide-border">
                             <nav className="grid gap-2 py-6">
                                 <a
@@ -135,7 +131,6 @@ export default function Navigation() {
                                         </AccordionContent>
                                     </AccordionItem>
                                 </Accordion>
-
                                 <a
                                     href="#"
                                     className="flex items-center space-x-2 rounded-md p-2 hover:bg-accent"


### PR DESCRIPTION
This commit introduces a major overhaul of the application's navigation and authentication systems, and updates the primary theme color.

Key changes include:

1.  **Social Login:**
    -   Users can now register and log in using Google, GitHub, Facebook, or Discord.
    -   Added a `SocialiteController` to handle OAuth flows.
    -   Created migrations to add social provider details and a fallback avatar to the `users` table.
    -   The `password` field is now nullable for social-only users.
    -   Added a prompt on the dashboard for social-only users to set a password.

2.  **Navigation Overhaul:**
    -   Replaced the old navigation with `shadcn/ui`'s `NavigationMenu`.
    -   Updated links to Home, Tokens (dropdown), About Us, and Blog.
    -   Implemented a new `UserNav` component to handle authentication state, showing either Login/Register buttons or a user dropdown with Profile/Settings/Logout links.
    -   The user avatar is displayed in the dropdown, using the social provider's image with a fallback to ui-avatars.com.

3.  **Mobile Navigation:**
    -   The mobile menu now mirrors the main navigation.
    -   The "Tokens" section is implemented as an accordion for a better mobile experience.
    -   The theme switcher has been moved to the bottom of the mobile menu.

4.  **Theme Update:**
    -   The primary CSS color has been changed to `amber-400`.